### PR TITLE
Add NumTimers and AwaitTimers to Mock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/benbjohnson/clock
+module github.com/wattch/clock
 
-go 1.15
+go 1.18


### PR DESCRIPTION
Forked the clock library to add new methods to the mock that would allow better synchronization in tests.